### PR TITLE
Refactor: Rename groups to tags

### DIFF
--- a/src/main/java/com/att/m2x/client/M2XClient.java
+++ b/src/main/java/com/att/m2x/client/M2XClient.java
@@ -85,14 +85,14 @@ public final class M2XClient
 	}
 
 	/**
-	 * List Device Groups
-	 * Retrieve the list of device groups for the authenticated user.
+	 * List Device Tags
+	 * Retrieve the list of device tags for the authenticated user.
 	 *
-	 * https://m2x.att.com/developer/documentation/v2/device#List-Device-Groups
+	 * https://m2x.att.com/developer/documentation/v2/device#List-Device-Tags
 	 */
-	public M2XResponse deviceGroups(String query) throws IOException
+	public M2XResponse deviceTags(String query) throws IOException
 	{
-		return makeRequest("GET", M2XDevice.URL_PATH + "/groups", query, null);
+		return makeRequest("GET", M2XDevice.URL_PATH + "/tags", query, null);
 	}
 
 	/**

--- a/src/test/java/com/att/m2x/client/M2XClientTests.java
+++ b/src/test/java/com/att/m2x/client/M2XClientTests.java
@@ -159,7 +159,7 @@ public class M2XClientTests extends M2XTestBase
 
 		// device
 
-		response = client.deviceGroups(null);
+		response = client.deviceTags(null);
 		assertThat(response.status, is(200));
 		assertThat(response.success(), is(true));
 		assertThat(response.error(), is(false));


### PR DESCRIPTION
The groups concept has been deprecated in favor of [tags](https://m2x.att.com/developer/documentation/v2/device#List-Device-Tags).

Add the necessary changes to this library to reflect that change.